### PR TITLE
Fixed total pnl calculation.

### DIFF
--- a/analytics/pnl.py
+++ b/analytics/pnl.py
@@ -109,12 +109,13 @@ def pnl(d=None, a=None):
     cash['PnL'] = 0
     cash.drop(['q', 'q_eod', 'q_eom', 'q_eoy'], axis=1, inplace=True)
 
-    result = pd.concat([result, cash])
-    result.reset_index(inplace=True, drop=True)
-
     today_total = result.Today.sum()
     mtd_total = result.MTD.sum()
     ytd_total = result.YTD.sum()
+
+    result = pd.concat([result, cash])
+    result.reset_index(inplace=True, drop=True)
+
     result.loc[len(result) + 1] = ['TOTAL', '', 0, 0, total_worth, today_total, mtd_total, ytd_total, 0]
 
     coh = result[result.Ticker == "CASH"]

--- a/analytics/tests/tests.py
+++ b/analytics/tests/tests.py
@@ -52,8 +52,15 @@ class PnLTests(TestCase):
     def test_sell(self):
         # AAPL was sold on 10/25/2021
         data, df = self.results(d=datetime.date(2021, 10, 25))
-        aapl_today = df[df.Ticker == 'AAPL'].Today[0]
+
+        aapl_today = list(df[df.Ticker == 'AAPL'].Today)[0]
         self.assertAlmostEqual(-400, aapl_today)
+
+        total_today = list(df[df.Account == 'TOTAL'].Today)[0]
+        self.assertAlmostEqual(3360.0, total_today)
+
+        cash_today = list(df[df.Ticker == 'CASH'].Today)[0]
+        self.assertAlmostEqual(24660.0, cash_today)
 
 
 @override_settings(USE_PRICE_FEED=False)


### PR DESCRIPTION
 In analytics.pnl.pnl() add cash after totaling.
Added analytics.tests.PnLTtests.test_sell().